### PR TITLE
Two quick bugfixes in setup.py and Adapters.py

### DIFF
--- a/nion/hyperspy/Adapters.py
+++ b/nion/hyperspy/Adapters.py
@@ -22,5 +22,8 @@ def signal_to_xdata(signal: hyperspy.signals.BaseSignal) -> DataAndMetadata.Data
     dimensional_calibrations = list()
     for axis in signal.axes_manager.navigation_axes + signal.axes_manager.signal_axes:
         dimensional_calibrations.append(Calibration.Calibration(axis.offset, axis.scale, axis.units))
-    data_descriptor = DataAndMetadata.DataDescriptor(False, len(signal.axes_manager.navigation_axes), len(signal.axes_manager.signal_axes))
+    if len(signal.axes_manager.signal_axes) == 0:
+        data_descriptor = DataAndMetadata.DataDescriptor(False, 0, len(signal.axes_manager.navigation_axes))
+    else:
+        data_descriptor = DataAndMetadata.DataDescriptor(False, len(signal.axes_manager.navigation_axes), len(signal.axes_manager.signal_axes))
     return DataAndMetadata.new_data_and_metadata(signal.data, dimensional_calibrations=dimensional_calibrations, data_descriptor=data_descriptor)

--- a/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
+++ b/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
@@ -16,14 +16,28 @@ processing_descriptions = {
     "nion.hyperspy.background":
         { 'script': '''# remove background with HyperSpy
 
-import hyperspy.api as hyperspy
+from hyperspy.models.model1d import Model1D
+from hyperspy import components1d
+from hyperspy.signals import Signal1D
 import nion.hyperspy
+import numpy as np
 
 signal = nion.hyperspy.xdata_to_signal(src.display_xdata)
 fit_px = int(fit_region.interval[0] * src.display_xdata.data_shape[0]), int(fit_region.interval[1] * src.display_xdata.data_shape[0])
 signal_px = int(signal_region.interval[0] * src.display_xdata.data_shape[0]), int(signal_region.interval[1] * src.display_xdata.data_shape[0])
-signal = signal.remove_background(signal_range=fit_px)
-target.xdata = nion.hyperspy.signal_to_xdata(signal)[signal_px[0]:signal_px[1]]
+model = Model1D(signal)
+background_estimator = components1d.PowerLaw()
+model.append(background_estimator)
+background_estimator.estimate_parameters(signal, fit_px[0], fit_px[1], only_current=False)
+oldax = signal.axes_manager.as_dictionary()
+newax = oldax['axis-0'].copy()
+newax['navigate'] = True
+newax['size'] = 3
+axes=[newax, oldax['axis-0']]
+model_signal = model.as_signal()
+result = (signal.data, model_signal.data, (signal - model_signal).data)
+result_signal = Signal1D(np.array(result), axes=axes)
+target.xdata = nion.hyperspy.signal_to_xdata(result_signal)[:, signal_px[0]:signal_px[1]]
 ''',
           'sources': [{'label': 'Source', 'name': 'src',
                        'requirements': [{"type": "dimensionality", "min": 1, "max": 1}],

--- a/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
+++ b/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
@@ -23,12 +23,13 @@ import nion.hyperspy
 import numpy as np
 
 signal = nion.hyperspy.xdata_to_signal(src.display_xdata)
-fit_px = int(fit_region.interval[0] * src.display_xdata.data_shape[0]), int(fit_region.interval[1] * src.display_xdata.data_shape[0])
+calibration = src.display_xdata.dimensional_calibrations[0]
+fit_px = calibration.convert_to_calibrated_value(int(fit_region.interval[0] * src.display_xdata.data_shape[0])), calibration.convert_to_calibrated_value(int(fit_region.interval[1] * src.display_xdata.data_shape[0]))
 signal_px = int(signal_region.interval[0] * src.display_xdata.data_shape[0]), int(signal_region.interval[1] * src.display_xdata.data_shape[0])
 model = Model1D(signal)
 background_estimator = components1d.PowerLaw()
 model.append(background_estimator)
-background_estimator.estimate_parameters(signal, fit_px[0], fit_px[1], only_current=False)
+background_estimator.estimate_parameters(signal, fit_px[0], fit_px[1])
 oldax = signal.axes_manager.as_dictionary()
 newax = oldax['axis-0'].copy()
 newax['navigate'] = True

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description=open("README.rst").read(),
     url="https://github.com/nion-software/nionswift-hyperspy",
     packages=["nion.hyperspy", "nionswift_plugin.nion_hyperspy"],
-    install_requires=['hyperspy', 'nionswift'],
+    install_requires=['hyperspy'],
     license='GPLv3',
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
     ],
     include_package_data=True,
+    # This prevents package from being installed in zipped form. Otherwise it will not be recognized by Swift.
+    # For more info see: https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
+    zip_safe=False,
     test_suite="nion.hyperspy.test",
     python_requires='~=3.5',
 )


### PR DESCRIPTION
The fix in setup.py should probably be included in all packages that are supposed to be installed with the new Swift plugin system.
The fix in Adapters.py works for regular spectrum images so I guess it is fine like this but I didn't test for data with other dimensionality than 3.