### PR TITLE
Fixed bug in passing fit range to hyperspy (should be in calibrated units but was in pixels) + two bugfixes in setup.py and Adapters.py

### DIFF
--- a/nion/hyperspy/Adapters.py
+++ b/nion/hyperspy/Adapters.py
@@ -22,5 +22,8 @@ def signal_to_xdata(signal: hyperspy.signals.BaseSignal) -> DataAndMetadata.Data
     dimensional_calibrations = list()
     for axis in signal.axes_manager.navigation_axes + signal.axes_manager.signal_axes:
         dimensional_calibrations.append(Calibration.Calibration(axis.offset, axis.scale, axis.units))
-    data_descriptor = DataAndMetadata.DataDescriptor(False, len(signal.axes_manager.navigation_axes), len(signal.axes_manager.signal_axes))
+    if len(signal.axes_manager.signal_axes) == 0:
+        data_descriptor = DataAndMetadata.DataDescriptor(False, 0, len(signal.axes_manager.navigation_axes))
+    else:
+        data_descriptor = DataAndMetadata.DataDescriptor(False, len(signal.axes_manager.navigation_axes), len(signal.axes_manager.signal_axes))
     return DataAndMetadata.new_data_and_metadata(signal.data, dimensional_calibrations=dimensional_calibrations, data_descriptor=data_descriptor)

--- a/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
+++ b/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
@@ -21,9 +21,9 @@ import nion.hyperspy
 
 signal = nion.hyperspy.xdata_to_signal(src.display_xdata)
 calibration = src.display_xdata.dimensional_calibrations[0]
-fit_px = calibration.convert_to_calibrated_value(int(fit_region.interval[0] * src.display_xdata.data_shape[0])), calibration.convert_to_calibrated_value(int(fit_region.interval[1] * src.display_xdata.data_shape[0]))
+fit_range = calibration.convert_to_calibrated_value(int(fit_region.interval[0] * src.display_xdata.data_shape[0])), calibration.convert_to_calibrated_value(int(fit_region.interval[1] * src.display_xdata.data_shape[0]))
 signal_px = int(signal_region.interval[0] * src.display_xdata.data_shape[0]), int(signal_region.interval[1] * src.display_xdata.data_shape[0])
-signal = signal.remove_background(signal_range=fit_px)
+signal = signal.remove_background(signal_range=fit_range)
 target.xdata = nion.hyperspy.signal_to_xdata(signal)[signal_px[0]:signal_px[1]]
 ''',
           'sources': [{'label': 'Source', 'name': 'src',
@@ -42,10 +42,11 @@ target.xdata = nion.hyperspy.signal_to_xdata(signal)[signal_px[0]:signal_px[1]]
 import hyperspy.api as hyperspy
 import nion.hyperspy
 
-fit_px = int(fit_region.interval[0] * src_fit.display_xdata.data_shape[0]), int(fit_region.interval[1] * src_fit.display_xdata.data_shape[0])
+calibration = src.display_xdata.dimensional_calibrations[0]
+fit_range = calibration.convert_to_calibrated_value(int(fit_region.interval[0] * src.display_xdata.data_shape[0])), calibration.convert_to_calibrated_value(int(fit_region.interval[1] * src.display_xdata.data_shape[0]))
 signal_px = int(signal_region.interval[0] * src_fit.display_xdata.data_shape[0]), int(signal_region.interval[1] * src_fit.display_xdata.data_shape[0])
 signal = nion.hyperspy.xdata_to_signal(src.xdata)
-signal = signal.remove_background(signal_range=fit_px).isig[signal_px[0]:signal_px[1]].integrate1D(2)
+signal = signal.remove_background(signal_range=fit_range).isig[signal_px[0]:signal_px[1]].integrate1D(2)
 target.xdata = nion.hyperspy.signal_to_xdata(signal)
 ''',
           'sources': [{'label': 'Fitting Source', 'name': 'src_fit',

--- a/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
+++ b/nionswift_plugin/nion_hyperspy/HyperSpyUI.py
@@ -20,7 +20,8 @@ import hyperspy.api as hyperspy
 import nion.hyperspy
 
 signal = nion.hyperspy.xdata_to_signal(src.display_xdata)
-fit_px = int(fit_region.interval[0] * src.display_xdata.data_shape[0]), int(fit_region.interval[1] * src.display_xdata.data_shape[0])
+calibration = src.display_xdata.dimensional_calibrations[0]
+fit_px = calibration.convert_to_calibrated_value(int(fit_region.interval[0] * src.display_xdata.data_shape[0])), calibration.convert_to_calibrated_value(int(fit_region.interval[1] * src.display_xdata.data_shape[0]))
 signal_px = int(signal_region.interval[0] * src.display_xdata.data_shape[0]), int(signal_region.interval[1] * src.display_xdata.data_shape[0])
 signal = signal.remove_background(signal_range=fit_px)
 target.xdata = nion.hyperspy.signal_to_xdata(signal)[signal_px[0]:signal_px[1]]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
     ],
     include_package_data=True,
+    # This prevents package from being installed in zipped form. Otherwise it will not be recognized by Swift.
+    # For more info see: https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
+    zip_safe=False,
     test_suite="nion.hyperspy.test",
     python_requires='~=3.5',
 )


### PR DESCRIPTION
The fix in setup.py should probably be included in all packages that are supposed to be installed with the new Swift plugin system.
The fix in Adapters.py works for regular spectrum images so I guess it is fine like this but I didn't test for data with other dimensionality than 3.